### PR TITLE
Add Portainer for Docker container management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,22 @@ services:
       - "traefik.http.routers.jellyfin.tls.certresolver=cloudflare"
       - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
 
+  portainer:
+    container_name: portainer
+    image: portainer/portainer-ce:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./portainer/data:/data
+    networks:
+      - proxy
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.woggles.work`)"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.routers.portainer.tls.certresolver=cloudflare"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+
   syncthing:
     container_name: syncthing
     image: lscr.io/linuxserver/syncthing:latest

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -20,6 +20,16 @@
           type: traefik
           url: https://traefik.woggles.work
 
+- Infrastructure:
+    - Portainer:
+        href: https://portainer.woggles.work
+        description: Docker container management
+        icon: portainer
+        widget:
+          type: portainer
+          url: http://portainer:9000
+          env: 1
+
 - Media:
     - Jellyfin:
         href: https://jellyfin.woggles.work


### PR DESCRIPTION
## Summary

- Adds Portainer CE as a new service with Traefik routing at `portainer.woggles.work`
- Mounts the Docker socket directly (Portainer needs write access, unlike the read-only dockerproxy)
- Adds an Infrastructure section to the homepage with a Portainer widget

## Notes

After first deploy, visit `https://portainer.woggles.work` promptly to create the admin account (it times out after a few minutes). Once set up, generate an API token in account settings and wire it up as `HOMEPAGE_VAR_PORTAINER_API_KEY` in `.env` + `services.yaml` for live widget stats.

## Test plan

- [ ] `docker compose up -d portainer` starts the container
- [ ] `https://portainer.woggles.work` is reachable and serves the setup UI
- [ ] Homepage Infrastructure section shows Portainer link
- [ ] Can manage (start/stop/restart) containers via Portainer UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)