### PR TITLE
Add missing Portainer API key to Homepage widget

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -29,6 +29,7 @@
           type: portainer
           url: http://portainer:9000
           env: 1
+          key: "{{HOMEPAGE_VAR_PORTAINER_API_KEY}}"
 
 - Media:
     - Jellyfin:


### PR DESCRIPTION
## Summary

- Adds `key: "{{HOMEPAGE_VAR_PORTAINER_API_KEY}}"` to the Portainer widget in `homepage/config/services.yaml`
- Without this field, Homepage fails to authenticate with Portainer and throws `API Error: Invalid JWT token`

## Test plan

- [ ] Add `HOMEPAGE_VAR_PORTAINER_API_KEY=<your_access_token>` to `.env` on the server
- [ ] Run `docker compose restart homepage`
- [ ] Verify the Portainer widget loads container stats without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)