### PR TITLE
Expose Portainer port 9000 on localhost for post-setup script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,8 @@ services:
   portainer:
     container_name: portainer
     image: portainer/portainer-ce:latest
+    ports:
+      - "127.0.0.1:9000:9000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./portainer/data:/data


### PR DESCRIPTION
## Summary

- Portainer had no host port binding — only reachable via Traefik internally
- The `post-setup.sh` script curls `http://localhost:9000` to fetch API keys, causing it to hang indefinitely waiting for a connection that would never arrive
- Binds `127.0.0.1:9000:9000` so the script can reach the Portainer API from the host without exposing it to the LAN

Pi-hole (`network_mode: host`) and Jellyfin (`8096:8096`) were already reachable from the host — Portainer was the only service missing a binding.

## Test plan

- [ ] `docker compose up -d portainer` on the server to pick up the port change
- [ ] Confirm `curl -sf http://localhost:9000/api/system/status` returns a response from the host
- [ ] Re-run `./scripts/post-setup.sh` and confirm Portainer no longer hangs on the wait step

🤖 Generated with [Claude Code](https://claude.com/claude-code)