### PR TITLE
Add inline comments to MEDIA_PATH and SYNC_PATH in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,5 @@ PORTAINER_API_KEY=
 PORTAINER_ENV_ID=
 
 # Media and sync paths (change when external HDD is mounted)
-MEDIA_PATH=/mnt/media
-SYNC_PATH=/mnt/sync
+MEDIA_PATH=/mnt/media  # Jellyfin media library root (mounted read-only)
+SYNC_PATH=/mnt/sync    # Syncthing data directory


### PR DESCRIPTION
## Summary

- Adds inline comments to `MEDIA_PATH` and `SYNC_PATH` clarifying which service each variable feeds (Jellyfin and Syncthing respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)