### PR TITLE
Add Wallabag read-it-later service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ FILEBROWSER_PATH=/mnt/data
 # Media and sync paths (change when external HDD is mounted)
 MEDIA_PATH=/mnt/media  # Jellyfin media library root (mounted read-only)
 SYNC_PATH=/mnt/sync    # Syncthing data directory
+
+# Wallabag (read-it-later)
+# Generate a random secret: openssl rand -hex 32
+WALLABAG_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
     #   docker exec wallabag php bin/console doctrine:migrations:migrate --env=prod
     environment:
       - SYMFONY__ENV__DOMAIN_NAME=https://wallabag.woggles.work
-      - SYMFONY__ENV__SECRET=${WALLABAG_SECRET}
+      - SYMFONY__ENV__SECRET=${WALLABAG_SECRET:-}
       - SYMFONY__ENV__DATABASE_DRIVER=pdo_sqlite
       - SYMFONY__ENV__FOSUSER_REGISTRATION=false
       - POPULATE_DATABASE=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,3 +187,30 @@ services:
       - "traefik.http.routers.syncthing.entrypoints=websecure"
       - "traefik.http.routers.syncthing.tls.certresolver=cloudflare"
       - "traefik.http.services.syncthing.loadbalancer.server.port=8384"
+
+  wallabag:
+    container_name: wallabag
+    image: wallabag/wallabag:2.6.14
+    # To upgrade: bump image tag, then run:
+    #   docker exec wallabag php bin/console doctrine:migrations:migrate --env=prod
+    environment:
+      - SYMFONY__ENV__DOMAIN_NAME=https://wallabag.woggles.work
+      - SYMFONY__ENV__SECRET=${WALLABAG_SECRET}
+      - SYMFONY__ENV__DATABASE_DRIVER=pdo_sqlite
+      - SYMFONY__ENV__FOSUSER_REGISTRATION=false
+      - POPULATE_DATABASE=True
+    volumes:
+      - ./wallabag/data:/var/www/wallabag/data
+      - wallabag_images:/var/www/wallabag/web/assets/images
+    networks:
+      - proxy
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wallabag.rule=Host(`wallabag.woggles.work`)"
+      - "traefik.http.routers.wallabag.entrypoints=websecure"
+      - "traefik.http.routers.wallabag.tls.certresolver=cloudflare"
+      - "traefik.http.services.wallabag.loadbalancer.server.port=80"
+
+volumes:
+  wallabag_images:

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -60,3 +60,9 @@
         href: https://files.woggles.work
         description: Drag-and-drop file transfer
         icon: filebrowser
+
+- Reading:
+    - Wallabag:
+        href: https://wallabag.woggles.work
+        description: Read-it-later
+        icon: wallabag

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -88,6 +88,7 @@ mkdir -p syncthing/config
 mkdir -p traefik/dynamic
 mkdir -p filebrowser/database
 mkdir -p filebrowser/config
+mkdir -p wallabag/data
 
 # Set proper permissions
 echo "🔐 Setting permissions..."
@@ -209,6 +210,25 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
     echo ""
 fi
 
+# Generate Wallabag secret if not already set
+echo "🔐 Setting up Wallabag secret..."
+if grep -q "^WALLABAG_SECRET=.\+" .env 2>/dev/null; then
+    echo -e "${GREEN}✅ WALLABAG_SECRET already set in .env${NC}"
+else
+    WALLABAG_SECRET=$(openssl rand -hex 32)
+    if grep -q "^WALLABAG_SECRET=" .env; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s|^WALLABAG_SECRET=.*|WALLABAG_SECRET=$WALLABAG_SECRET|" .env
+        else
+            sed -i "s|^WALLABAG_SECRET=.*|WALLABAG_SECRET=$WALLABAG_SECRET|" .env
+        fi
+    else
+        echo "WALLABAG_SECRET=$WALLABAG_SECRET" >> .env
+    fi
+    echo -e "${GREEN}✅ WALLABAG_SECRET generated and written to .env${NC}"
+fi
+echo ""
+
 echo ""
 echo -e "${GREEN}✅ Setup complete!${NC}"
 echo ""
@@ -243,6 +263,7 @@ echo "   https://traefik.woggles.work   — Traefik dashboard"
 echo "   https://jellyfin.woggles.work  — Media server"
 echo "   https://syncthing.woggles.work — File sync"
 echo "   https://files.woggles.work     — FileBrowser (random password — run: docker logs filebrowser)"
+echo "   https://wallabag.woggles.work  — Read-it-later (default login: wallabag/wallabag — change immediately)"
 echo ""
 echo "6. Enable Tailscale remote access:"
 echo "   sudo tailscale up --ssh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,6 +94,7 @@ mkdir -p wallabag/data
 echo "🔐 Setting permissions..."
 chmod 777 filebrowser/database
 chmod 777 filebrowser/config
+chmod 777 wallabag/data
 
 echo -e "${GREEN}✅ Directories created${NC}"
 echo ""
@@ -227,8 +228,6 @@ else
     fi
     echo -e "${GREEN}✅ WALLABAG_SECRET generated and written to .env${NC}"
 fi
-echo ""
-
 echo ""
 echo -e "${GREEN}✅ Setup complete!${NC}"
 echo ""


### PR DESCRIPTION
## Summary

- Adds `wallabag/wallabag:2.6.14` service to `docker-compose.yml` with SQLite backend and Traefik routing at `wallabag.woggles.work`
- Adds `wallabag_images` named volume (avoids host UID permission issues for article images)
- Adds `WALLABAG_SECRET` to `.env.example`
- Adds Wallabag to the Homepage dashboard under a new "Reading" group (plain link, no widget)
- `setup.sh` now auto-generates `WALLABAG_SECRET` via `openssl rand -hex 32` and creates the `wallabag/data` directory

Closes #32

## Test plan

- [ ] Deploy on server: `docker compose up -d wallabag`
- [ ] Visit `https://wallabag.woggles.work` — confirm CSS loads correctly (subdomain routing required for absolute internal links)
- [ ] Log in with default credentials (`wallabag` / `wallabag`) and change password immediately
- [ ] Confirm Wallabag appears in Homepage dashboard under "Reading"
- [ ] Run `./scripts/lint-config.sh` — exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)