### PR TITLE
Add .gitattributes and README badges

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# GitHub Linguist overrides
+# YAML is classified as a "data" language and hidden from the language bar.
+# Override Docker Compose and Traefik config to show as Dockerfile so the
+# container orchestration work is reflected in the repo stats.
+docker-compose.yml      linguist-language=Dockerfile
+docker-compose.*.yml    linguist-language=Dockerfile
+traefik/traefik.yml     linguist-language=Dockerfile
+traefik/dynamic/*.yml   linguist-language=Dockerfile
+
+# Exclude lockfiles and generated node files from language stats
+pnpm-lock.yaml          linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,3 @@ docker-compose.yml      linguist-language=Dockerfile
 docker-compose.*.yml    linguist-language=Dockerfile
 traefik/traefik.yml     linguist-language=Dockerfile
 traefik/dynamic/*.yml   linguist-language=Dockerfile
-
-# Exclude lockfiles and generated node files from language stats
-pnpm-lock.yaml          linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Home Network Server
 
+[![CI](https://github.com/riccjohn/home-network/actions/workflows/ci.yml/badge.svg)](https://github.com/riccjohn/home-network/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Docker Compose](https://img.shields.io/badge/docker_compose-2496ED?logo=docker&logoColor=white)
+![Traefik](https://img.shields.io/badge/traefik_v3-24A1C1?logo=traefikproxy&logoColor=white)
+![Ubuntu](https://img.shields.io/badge/ubuntu_server-E95420?logo=ubuntu&logoColor=white)
 
 Self-hosted home server stack running on Ubuntu Server (Lenovo ThinkCentre), managed with Docker Compose. Traefik handles reverse proxying and wildcard TLS via Cloudflare DNS-01 challenge.
 


### PR DESCRIPTION
## Summary

- **`.gitattributes`** — overrides GitHub Linguist so Docker Compose and Traefik YAML files show as Dockerfile in the language bar. YAML is classified as a "data" language by Linguist and hidden from repo stats; this is the standard workaround to surface the container orchestration work
- **`README.md`** — adds CI status badge and tech stack badges (Docker Compose, Traefik v3, Ubuntu Server) alongside the existing license badge

## Test plan

- [ ] GitHub repo page shows Dockerfile (and Shell) in the language bar after merge
- [ ] CI badge links to the Actions workflow and shows current status
- [ ] Tech stack badges render correctly on the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)