### PR TITLE
Ignore calibre-web/config runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ syncthing/config/
 portainer/data/
 filebrowser/database/
 filebrowser/config/
+calibre-web/config/


### PR DESCRIPTION
## Summary

- Adds `calibre-web/config/` to `.gitignore` to prevent runtime container data from being tracked, consistent with how `jellyfin/config/`, `syncthing/config/`, `portainer/data/`, etc. are handled

## Test plan

- [x] `./scripts/lint-config.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)